### PR TITLE
Fix issue 2 iOS9 Facebook LSApplicationQueriesSchemes

### DIFF
--- a/iOS/basic-sample-swift/SwiftSample/Info.plist
+++ b/iOS/basic-sample-swift/SwiftSample/Info.plist
@@ -41,6 +41,13 @@
 	<string>696506353719958</string>
 	<key>FacebookDisplayName</key>
 	<string>MyApplication</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+	        <string>fbapi</string>
+	        <string>fb-messenger-api</string>
+	        <string>fbauth2</string>
+	        <string>fbshareextension</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>SampleAPIBaseURL</key>


### PR DESCRIPTION
Fixes an issue where LSApplicationQueriesSchemes has to be set for
Lock-Facebook to work on iOS 9.

Fixes https://github.com/auth0/native-mobile-samples/issues/2
