### PR TITLE
Unwrap id_token from keychain and add localhost exception

### DIFF
--- a/iOS/basic-sample-swift/SwiftSample/Info.plist
+++ b/iOS/basic-sample-swift/SwiftSample/Info.plist
@@ -6,6 +6,19 @@
 	<string>{CLIENT_ID}</string>
 	<key>Auth0Domain</key>
 	<string>{DOMAIN}</string>
+	<key>NSAppTransportSecurity</key>
+  <dict>
+      <key>NSExceptionDomains</key>
+      <dict>
+          <key>localhost</key>
+          <dict>
+              <key>NSExceptionAllowsInsecureHTTPLoads</key>
+              <true/>
+              <key>NSIncludesSubdomains</key>
+              <true/>
+          </dict>
+      </dict>
+  </dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/iOS/basic-sample-swift/SwiftSample/ProfileViewController.swift
+++ b/iOS/basic-sample-swift/SwiftSample/ProfileViewController.swift
@@ -59,7 +59,7 @@ class ProfileViewController: UIViewController {
         let urlString = info["SampleAPIBaseURL"] as! String
         let request = NSMutableURLRequest(URL: NSURL(string: urlString)!)
         let keychain = MyApplication.sharedInstance.keychain
-        let token = keychain.stringForKey("id_token")
+        let token = keychain.stringForKey("id_token")!
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         return request
     }


### PR DESCRIPTION
The id_token has to be unwrapped to be used correctly, since it is an
optional string when retrieved from the keychain.
Also the NSAppTransportSecurity policy needs to include an exception
for the localhost domain so that the seed works right ahead with
backend seeds like NodeJS.

Fixes https://github.com/auth0/native-mobile-samples/issues/10 and
https://github.com/auth0/native-mobile-samples/issues/11
