### PR TITLE
iOS Swift Sample - Update Lock

### DIFF
--- a/iOS/basic-sample-swift/Podfile
+++ b/iOS/basic-sample-swift/Podfile
@@ -4,8 +4,8 @@ inhibit_all_warnings!
 use_frameworks!
 
 target "SwiftSample" do
-  pod "Lock", "~> 1.12"
-  pod "Lock-Facebook", "~> 2.0"
+  pod "Lock", "~> 1.22"
+  pod "Lock-Facebook", "~> 2.2"
   pod "JWTDecode", "~> 1.0"
   pod "SimpleKeychain", "~> 0.3"
   pod "MBProgressHUD", "~> 0.9"

--- a/iOS/basic-sample-swift/SwiftSample/Info.plist
+++ b/iOS/basic-sample-swift/SwiftSample/Info.plist
@@ -17,6 +17,27 @@
               <key>NSIncludesSubdomains</key>
               <true/>
           </dict>
+					<key>facebook.com</key>
+	        <dict>
+	            <key>NSIncludesSubdomains</key>
+	            <true/>
+	            <key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+	            <false/>
+	        </dict>
+	        <key>fbcdn.net</key>
+	        <dict>
+	            <key>NSIncludesSubdomains</key>
+	            <true/>
+	            <key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+	            <false/>
+	        </dict>
+	        <key>akamaihd.net</key>
+	        <dict>
+	            <key>NSIncludesSubdomains</key>
+	            <true/>
+	            <key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+	            <false/>
+	        </dict>
       </dict>
   </dict>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
Updates Lock on the iOS Swift sample and adds exception domains to
enable Facebook authentication on iOS 9.

Fixes https://github.com/auth0/native-mobile-samples/issues/17
